### PR TITLE
Add support for forthcoming `isJSON` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 node_js:
     - "0.10"
     - "0.12"
+    - 4
+    - 5
+    - 6

--- a/lib/exposed.js
+++ b/lib/exposed.js
@@ -20,6 +20,11 @@ function Exposed() {
         // examined and removed if they would end up being noops.
         __namespaces__: {value: []},
 
+        // Defines a "hidden" property that stores with the value of
+        // `options.isJSON` that `add()` was called with. This allows for a
+        // hot-path to be taken during serialization.
+        __json__: {value: {}},
+
         // Defines a "hidden" property that stores serializations of data by
         // namespace that was exposed and deemed cacheable; e.g. won't be
         // changing. This allows the `toString()` method to run *much* faster.
@@ -28,18 +33,19 @@ function Exposed() {
 }
 
 Exposed.create = function (exposed) {
+    // If we're not inheriting, return a new instance.
     if (!Exposed.isExposed(exposed)) {
         return new Exposed();
     }
 
     // Creates a new exposed object with the specified `exposed` instance as its
     // prototype. This allows the new object to inherit from, *and* shadow the
-    // existing object. A prototype relationship is also setup for the
-    // serialized cached state, aggregation of applicable namespaces happens at
+    // existing object. Aggregation of applicable namespaces happens at
     // `toString()` time.
     return Object.create(exposed, {
         __namespaces__: {value: []},
-        __serialized__: {value: Object.create(exposed.__serialized__)}
+        __json__      : {value: {}},
+        __serialized__: {value: {}}
     });
 };
 
@@ -48,15 +54,19 @@ Exposed.isExposed = function (obj) {
 };
 
 Exposed.prototype.add = function (namespace, value, options) {
+    options || (options = {});
+
     var nsRegex       = new RegExp('^' + namespace + '(?:$|\\..+)'),
         namespaces    = this.__namespaces__,
         oldNamespaces = namespaces.filter(nsRegex.test.bind(nsRegex)),
+        json          = this.__json__,
         serialized    = this.__serialized__;
 
-    // Removes previously exposed namespaces, values, and serialized state which
-    // no longer apply and have become noops.
+    // Removes previously exposed namespaces, values, isJSON setting, and
+    // serialized state which no longer apply and have become noops.
     oldNamespaces.forEach(function (namespace) {
         namespaces.splice(namespaces.indexOf(namespace), 1);
+        delete json[namespace];
         delete serialized[namespace];
         delete this[namespace];
     }, this);
@@ -65,11 +75,16 @@ Exposed.prototype.add = function (namespace, value, options) {
     namespaces.push(namespace);
     this[namespace] = value;
 
+    // Stores the value of `options.isJSON` so it can be passed along to
+    // `serialize()`. When set, this option speeds up serialization.
+    var isJSON = !!options.isJSON;
+    json[namespace] = isJSON;
+
     // When it's deemed safe to cache the serialized form of the `value` because
     // it won't change, run the serialization process once, eagerly. The result
     // is cached to greatly optimize to speed of the `toString()` method.
-    if (options && options.cache) {
-        serialized[namespace] = serialize(value);
+    if (options.cache) {
+        serialized[namespace] = serialize(value, {isJSON: isJSON});
     }
 };
 
@@ -156,17 +171,18 @@ Exposed.prototype._getApplicableNamespaces = function () {
 };
 
 Exposed.prototype._getSerializedValue = function (namespace) {
-    var serialized = this.__serialized__,
+    var json       = this.__json__,
+        serialized = this.__serialized__,
         proto;
 
     // Own pre-serialized value.
-    if (serialized.hasOwnProperty(namespace)) {
+    if (serialized[namespace]) {
         return serialized[namespace];
     }
 
     // Own value, serialized.
     if (this.hasOwnProperty(namespace)) {
-        return serialize(this[namespace]);
+        return serialize(this[namespace], {isJSON: json[namespace]});
     }
 
     // Walk prototype to find the value...

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "express": ">=3.x"
   },
   "dependencies": {
-    "serialize-javascript": "~1.1.0"
+    "serialize-javascript": "^1.1.0"
   },
   "devDependencies": {
     "chai": "*",


### PR DESCRIPTION
This adds support for the forthcoming `isJSON` option being added to `serialize-javascript` to help speed up serialization for pure JSON data.

https://github.com/yahoo/serialize-javascript/pull/17